### PR TITLE
Feat:  cache metrics (json and chart)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.env.local
+.gitignore
+.git
+.github
+.vscode
+README.md
+e2e
+tmp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,18 @@ deno fmt
 
 ## Architecture
 
-Single-file application (`src/index.ts`) built on Hono with typed bindings for
-env vars and an S3Client context variable.
+Modular application built on Hono with typed bindings (`AppEnv` in
+`src/types.ts`) for env vars and an S3Client context variable.
+
+**Structure:**
+
+- `src/index.ts` — app setup, middleware registration, route registration
+- `src/types.ts` — shared `AppEnv` type definition
+- `src/middleware/auth.ts` — Bearer token authentication
+- `src/middleware/s3.ts` — S3 client initialization
+- `src/routes/cache.ts` — cache PUT/GET endpoints
+- `src/routes/metrics.ts` — metrics endpoints
+- `src/metrics/cacheHitRate.ts` — in-memory metrics tracking
 
 **Request flow:** S3Client init middleware -> Logger middleware -> Auth
 middleware (Bearer token) -> Route handler
@@ -47,9 +57,11 @@ middleware (Bearer token) -> Route handler
 **Routes:**
 
 - `GET /health` — health check (no auth)
-- `PUT /v1/cache/:hash` — upload artifact to S3 (checks for duplicates with
-  HeadObject, returns 409 on conflict)
+- `PUT /v1/cache/:hash` — upload artifact to S3 (requires Content-Length header,
+  checks for duplicates with HeadObject, returns 409 on conflict)
 - `GET /v1/cache/:hash` — download artifact via S3 presigned URL
+- `GET /v1/metrics/json` — JSON time series of cache hit/miss data
+- `GET /v1/metrics/chart` — HTML page with inline SVG chart
 
 **Key pattern:** The Hono `app` is exported separately from server startup
 (`if (import.meta.main)`), allowing unit tests to call `app.fetch()` directly
@@ -72,7 +84,8 @@ Both suites are self-contained — no Docker, no separate `deno task dev`.
 
 Required at runtime: `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
 `S3_BUCKET_NAME`, `S3_ENDPOINT_URL`, `NX_CACHE_ACCESS_TOKEN`. Optional: `PORT`
-(default 3000).
+(default 3000), `METRICS_AUTH` (default `true` — set to `false` to disable auth
+on metrics endpoints).
 
 Local dev values are in `.env.local` (emulate.dev's seeded IAM defaults:
 `AKIAIOSFODNN7EXAMPLE` / `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`, bucket

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ and provides a production-ready solution for self-hosting your Nx remote cache.
 - Efficient file streaming
 - Production-ready implementation
 - Available as a Docker image
+- Cache hit rate metrics (JSON and chart endpoints)
 
 ## Prerequisites
 
@@ -37,7 +38,8 @@ AWS_SECRET_ACCESS_KEY=your-secret-key
 S3_BUCKET_NAME=your-bucket-name
 S3_ENDPOINT_URL=your-s3-endpoint-url
 NX_CACHE_ACCESS_TOKEN=your-secure-token
-PORT=3000  # Optional, defaults to 3000
+PORT=3000         # Optional, defaults to 3000
+METRICS_AUTH=true # Optional, defaults to true. Set to false to disable auth on metrics endpoints
 ```
 
 ## Installation
@@ -119,6 +121,24 @@ deno task e2e
 
 Both suites boot their own emulator and (for e2e) cache server — no separate
 setup is required.
+
+## Metrics
+
+The server tracks cache hit/miss statistics and exposes them via two endpoints:
+
+- `GET /v1/metrics/json` — JSON time series data
+- `GET /v1/metrics/chart` — HTML page with inline SVG chart
+
+Both endpoints support query parameters:
+
+- `window` — time window (default `6h`). Supports: `30m`, `1h`, `6h`, `1d`, etc.
+- `bucket` — aggregation bucket size (default `1m`). Supports: `1m`, `5m`, `1h`,
+  etc.
+
+Example: `/v1/metrics/chart?window=1h&bucket=5m`
+
+**Note:** Metrics are currently stored in memory and reset on server restart. S3
+persistence is planned for a future version.
 
 ## Usage with Nx
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,68 +1,15 @@
 import { Hono } from 'hono';
-import { createMiddleware } from 'hono/factory';
 import { logger } from 'hono/logger';
 
-import {
-  GetObjectCommand,
-  HeadObjectCommand,
-  PutObjectCommand,
-  S3Client,
-} from '@aws-sdk/client-s3';
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { auth } from './middleware/auth.ts';
+import { s3Middleware } from './middleware/s3.ts';
+import { registerCacheRoutes } from './routes/cache.ts';
+import { registerMetricsRoutes } from './routes/metrics.ts';
+import type { AppEnv } from './types.ts';
 
-export const app = new Hono<{
-  Bindings: {
-    NX_CACHE_ACCESS_TOKEN: string;
-    AWS_REGION: string;
-    AWS_ACCESS_KEY_ID: string;
-    AWS_SECRET_ACCESS_KEY: string;
-    S3_BUCKET_NAME: string;
-    S3_ENDPOINT_URL: string;
-  };
-  Variables: {
-    s3: S3Client;
-  };
-}>();
+export const app = new Hono<AppEnv>();
 
-app.use(async (c, next) => {
-  c.set(
-    's3',
-    new S3Client({
-      region: c.env.AWS_REGION,
-      endpoint: c.env.S3_ENDPOINT_URL,
-      credentials: {
-        accessKeyId: c.env.AWS_ACCESS_KEY_ID,
-        secretAccessKey: c.env.AWS_SECRET_ACCESS_KEY,
-      },
-      forcePathStyle: true,
-    }),
-  );
-
-  await next();
-});
-
-const auth = () =>
-  createMiddleware(async (c, next) => {
-    const authHeader = c.req.header('Authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return new Response('Missing or invalid authentication token', {
-        status: 401,
-        headers: { 'Content-Type': 'text/plain' },
-      });
-    }
-
-    const token = authHeader.split(' ')[1];
-
-    if (token !== c.env.NX_CACHE_ACCESS_TOKEN) {
-      return new Response('Missing or invalid authentication token', {
-        status: 401,
-        headers: { 'Content-Type': 'text/plain' },
-      });
-    }
-
-    await next();
-  });
-
+app.use(s3Middleware());
 app.use(logger());
 
 app.get('/health', () => {
@@ -72,124 +19,11 @@ app.get('/health', () => {
   });
 });
 
-app.put('/v1/cache/:hash', auth(), async (c) => {
-  try {
-    const hash = c.req.param('hash');
+// original cache functionality, now registered from a module
+registerCacheRoutes(app, auth);
 
-    const contentLength = c.req.header('Content-Length');
-    if (contentLength === undefined || Number.isNaN(Number(contentLength))) {
-      return new Response('Content-Length header is required', {
-        status: 411,
-        headers: { 'Content-Type': 'text/plain' },
-      });
-    }
-
-    try {
-      await c.get('s3').send(
-        new HeadObjectCommand({
-          Bucket: c.env.S3_BUCKET_NAME,
-          Key: hash,
-        }),
-      );
-
-      return new Response('Cannot override an existing record', {
-        status: 409,
-        headers: { 'Content-Type': 'text/plain' },
-      });
-    } catch (error: unknown) {
-      if (error instanceof Error && error.name === 'NotFound') {
-        // Do nothing
-      } else {
-        console.error('Upload error:', error);
-        return new Response('Internal server error', {
-          status: 500,
-          headers: { 'Content-Type': 'text/plain' },
-        });
-      }
-    }
-
-    const body = await c.req.arrayBuffer();
-
-    await c.get('s3').send(
-      new PutObjectCommand({
-        Bucket: c.env.S3_BUCKET_NAME,
-        Key: hash,
-        Body: new Uint8Array(body),
-      }),
-    );
-
-    return new Response('Successfully uploaded', {
-      status: 200,
-      headers: { 'Content-Type': 'text/plain' },
-    });
-  } catch (error: unknown) {
-    console.error('Upload error:', error);
-    return new Response('Internal server error', {
-      status: 500,
-      headers: { 'Content-Type': 'text/plain' },
-    });
-  }
-});
-
-app.get('/v1/cache/:hash', auth(), async (c) => {
-  try {
-    const hash = c.req.param('hash');
-
-    const command = new GetObjectCommand({
-      Bucket: c.env.S3_BUCKET_NAME,
-      Key: hash,
-    });
-
-    const url = await getSignedUrl(c.get('s3'), command, {
-      expiresIn: 18000,
-    });
-
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      console.error('Download error:', response.statusText);
-
-      await response.body?.cancel();
-
-      if (response.status === 404) {
-        return new Response('The record was not found', {
-          status: 404,
-          headers: { 'Content-Type': 'text/plain' },
-        });
-      }
-
-      return new Response('Access forbidden', {
-        status: 403,
-        headers: { 'Content-Type': 'text/plain' },
-      });
-    }
-
-    const headers = new Headers({
-      'Content-Type': 'application/octet-stream',
-    });
-    const contentLength = response.headers.get('Content-Length');
-    if (contentLength) {
-      headers.set('Content-Length', contentLength);
-    }
-
-    return new Response(response.body, {
-      status: 200,
-      headers,
-    });
-  } catch (error: unknown) {
-    if (error instanceof Error && error.name === 'NoSuchKey') {
-      return new Response('The record was not found', {
-        status: 404,
-        headers: { 'Content-Type': 'text/plain' },
-      });
-    }
-    console.error('Download error:', error);
-    return new Response('Internal server error', {
-      status: 500,
-      headers: { 'Content-Type': 'text/plain' },
-    });
-  }
-});
+// new metrics endpoints, separate module
+registerMetricsRoutes(app, auth);
 
 if (import.meta.main) {
   const port = parseInt(Deno.env.get('PORT') || '3000');
@@ -203,5 +37,6 @@ if (import.meta.main) {
       AWS_SECRET_ACCESS_KEY: Deno.env.get('AWS_SECRET_ACCESS_KEY'),
       S3_BUCKET_NAME: Deno.env.get('S3_BUCKET_NAME') || 'nx-cloud',
       S3_ENDPOINT_URL: Deno.env.get('S3_ENDPOINT_URL'),
+      METRICS_AUTH: Deno.env.get('METRICS_AUTH') || 'true',
     }));
 }

--- a/src/metrics/cacheHitRate.ts
+++ b/src/metrics/cacheHitRate.ts
@@ -1,0 +1,153 @@
+export type CacheBucket = {
+  ts: number; // bucket start timestamp (ms)
+  hits: number;
+  misses: number;
+  requests: number;
+};
+
+export type CacheHitRatePoint = {
+  ts: number;
+  hits: number;
+  misses: number;
+  requests: number;
+  hitRate: number | null;
+};
+
+export type CacheHitRateSeries = {
+  start: number;
+  end: number;
+  bucketMs: number;
+  points: CacheHitRatePoint[];
+  totals: {
+    hits: number;
+    misses: number;
+    requests: number;
+    hitRate: number | null;
+  };
+};
+
+const DEFAULT_BUCKET_MS = 60_000; // 1 minute
+const DEFAULT_RETENTION_MS = 24 * 60 * 60_000; // 24 hours
+
+const cacheBuckets = new Map<number, CacheBucket>();
+
+function floorToBucket(ts: number, bucketMs: number) {
+  return Math.floor(ts / bucketMs) * bucketMs;
+}
+
+function pruneOldBuckets(now: number, retentionMs: number) {
+  const cutoff = now - retentionMs;
+  for (const key of cacheBuckets.keys()) {
+    if (key < cutoff) cacheBuckets.delete(key);
+  }
+}
+
+/**
+ * Record GET cache outcomes:
+ * - 200 => hit
+ * - 404 => miss
+ * Other statuses count as request only (unless you decide otherwise later).
+ */
+export function recordCacheGetOutcome(
+  status: number,
+  now = Date.now(),
+  bucketMs = DEFAULT_BUCKET_MS,
+) {
+  const bucketTs = floorToBucket(now, bucketMs);
+  const existing = cacheBuckets.get(bucketTs) ?? {
+    ts: bucketTs,
+    hits: 0,
+    misses: 0,
+    requests: 0,
+  };
+
+  existing.requests += 1;
+  if (status === 200) existing.hits += 1;
+  else if (status === 404) existing.misses += 1;
+
+  cacheBuckets.set(bucketTs, existing);
+  pruneOldBuckets(now, DEFAULT_RETENTION_MS);
+}
+
+export function parseDurationMs(
+  input: string | null | undefined,
+  fallbackMs: number,
+): number {
+  if (!input) return fallbackMs;
+  const v = input.trim().toLowerCase();
+
+  // supports: 30m, 6h, 1d, 900s, 60000 (ms)
+  const m = v.match(/^(\d+)(ms|s|m|h|d)?$/);
+  if (!m) return fallbackMs;
+
+  const n = Number(m[1]);
+  const unit = m[2] ?? 'ms';
+
+  switch (unit) {
+    case 'ms':
+      return n;
+    case 's':
+      return n * 1000;
+    case 'm':
+      return n * 60_000;
+    case 'h':
+      return n * 60 * 60_000;
+    case 'd':
+      return n * 24 * 60 * 60_000;
+    default:
+      return fallbackMs;
+  }
+}
+
+export function computeHitRateSeries(
+  now: number,
+  windowMs: number,
+  bucketMs: number,
+): CacheHitRateSeries {
+  const start = now - windowMs;
+
+  // Aggregate into requested bucket size (can be coarser than storage bucket)
+  const series = new Map<number, CacheBucket>();
+
+  for (const b of cacheBuckets.values()) {
+    if (b.ts < start || b.ts > now) continue;
+
+    const ts = floorToBucket(b.ts, bucketMs);
+    const agg = series.get(ts) ?? { ts, hits: 0, misses: 0, requests: 0 };
+    agg.hits += b.hits;
+    agg.misses += b.misses;
+    agg.requests += b.requests;
+    series.set(ts, agg);
+  }
+
+  const points: CacheHitRatePoint[] = Array.from(series.values())
+    .sort((a, b) => a.ts - b.ts)
+    .map((b) => ({
+      ts: b.ts,
+      hits: b.hits,
+      misses: b.misses,
+      requests: b.requests,
+      hitRate: b.requests ? b.hits / b.requests : null,
+    }));
+
+  const totals = points.reduce(
+    (acc, p) => {
+      acc.hits += p.hits;
+      acc.misses += p.misses;
+      acc.requests += p.requests;
+      return acc;
+    },
+    { hits: 0, misses: 0, requests: 0 },
+  );
+
+  return {
+    start,
+    end: now,
+    bucketMs,
+    points,
+    totals: {
+      ...totals,
+      hitRate: totals.requests ? totals.hits / totals.requests : null,
+    },
+  };
+}

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,23 @@
+import { createMiddleware } from 'hono/factory';
+
+export const auth = () =>
+  createMiddleware(async (c, next) => {
+    const authHeader = c.req.header('Authorization');
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return new Response('Missing or invalid authentication token', {
+        status: 401,
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    }
+
+    const token = authHeader.split(' ')[1];
+
+    if (token !== c.env.NX_CACHE_ACCESS_TOKEN) {
+      return new Response('Missing or invalid authentication token', {
+        status: 401,
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    }
+
+    await next();
+  });

--- a/src/middleware/s3.ts
+++ b/src/middleware/s3.ts
@@ -1,0 +1,22 @@
+import type { S3Client } from '@aws-sdk/client-s3';
+import { S3Client as S3ClientImpl } from '@aws-sdk/client-s3';
+import type { MiddlewareHandler } from 'hono';
+
+export const s3Middleware = (): MiddlewareHandler => {
+  return async (c, next) => {
+    c.set(
+      's3',
+      new S3ClientImpl({
+        region: c.env.AWS_REGION,
+        endpoint: c.env.S3_ENDPOINT_URL,
+        credentials: {
+          accessKeyId: c.env.AWS_ACCESS_KEY_ID,
+          secretAccessKey: c.env.AWS_SECRET_ACCESS_KEY,
+        },
+        forcePathStyle: true,
+      }) as S3Client,
+    );
+
+    await next();
+  };
+};

--- a/src/routes/cache.ts
+++ b/src/routes/cache.ts
@@ -1,0 +1,137 @@
+import type { Hono } from 'hono';
+
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+
+import { recordCacheGetOutcome } from '../metrics/cacheHitRate.ts';
+import type { AppEnv } from '../types.ts';
+
+// deno-lint-ignore no-explicit-any
+export function registerCacheRoutes(app: Hono<AppEnv>, auth: () => any) {
+  app.put('/v1/cache/:hash', auth(), async (c) => {
+    try {
+      const hash = c.req.param('hash');
+
+      const contentLength = c.req.header('Content-Length');
+      if (contentLength === undefined || Number.isNaN(Number(contentLength))) {
+        return new Response('Content-Length header is required', {
+          status: 411,
+          headers: { 'Content-Type': 'text/plain' },
+        });
+      }
+
+      try {
+        await c.get('s3').send(
+          new HeadObjectCommand({
+            Bucket: c.env.S3_BUCKET_NAME,
+            Key: hash,
+          }),
+        );
+
+        return new Response('Cannot override an existing record', {
+          status: 409,
+          headers: { 'Content-Type': 'text/plain' },
+        });
+      } catch (error: unknown) {
+        if (error instanceof Error && error.name === 'NotFound') {
+          // Do nothing
+        } else {
+          console.error('Upload error:', error);
+          return new Response('Internal server error', {
+            status: 500,
+            headers: { 'Content-Type': 'text/plain' },
+          });
+        }
+      }
+
+      const body = await c.req.arrayBuffer();
+
+      await c.get('s3').send(
+        new PutObjectCommand({
+          Bucket: c.env.S3_BUCKET_NAME,
+          Key: hash,
+          Body: new Uint8Array(body),
+        }),
+      );
+
+      return new Response('Successfully uploaded', {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    } catch (error: unknown) {
+      console.error('Upload error:', error);
+      return new Response('Internal server error', {
+        status: 500,
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    }
+  });
+
+  app.get('/v1/cache/:hash', auth(), async (c) => {
+    try {
+      const hash = c.req.param('hash');
+
+      const command = new GetObjectCommand({
+        Bucket: c.env.S3_BUCKET_NAME,
+        Key: hash,
+      });
+
+      const url = await getSignedUrl(c.get('s3'), command, {
+        expiresIn: 18000,
+      });
+
+      const response = await fetch(url);
+
+      // record cache hit/miss
+      recordCacheGetOutcome(response.status);
+
+      if (!response.ok) {
+        console.error('Download error:', response.statusText);
+
+        await response.body?.cancel();
+
+        if (response.status === 404) {
+          return new Response('The record was not found', {
+            status: 404,
+            headers: { 'Content-Type': 'text/plain' },
+          });
+        }
+
+        return new Response('Access forbidden', {
+          status: 403,
+          headers: { 'Content-Type': 'text/plain' },
+        });
+      }
+
+      const headers = new Headers({
+        'Content-Type': 'application/octet-stream',
+      });
+      const responseContentLength = response.headers.get('Content-Length');
+      if (responseContentLength) {
+        headers.set('Content-Length', responseContentLength);
+      }
+
+      return new Response(response.body, {
+        status: 200,
+        headers,
+      });
+    } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'NoSuchKey') {
+        recordCacheGetOutcome(404);
+        return new Response('The record was not found', {
+          status: 404,
+          headers: { 'Content-Type': 'text/plain' },
+        });
+      }
+      console.error('Download error:', error);
+      return new Response('Internal server error', {
+        status: 500,
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    }
+  });
+}

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -1,0 +1,188 @@
+import type { Context, Hono } from 'hono';
+
+import {
+  computeHitRateSeries,
+  parseDurationMs,
+} from '../metrics/cacheHitRate.ts';
+import type { AppEnv } from '../types.ts';
+
+function escapeHtml(s: string) {
+  return s
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+function formatPct(x: number | null) {
+  if (x === null || Number.isNaN(x)) return '—';
+  return `${(x * 100).toFixed(1)}%`;
+}
+
+function renderHitRateSvg(
+  points: Array<{ ts: number; hitRate: number | null }>,
+) {
+  const width = 720;
+  const height = 180;
+  const padL = 44, padR = 12, padT = 14, padB = 28;
+  const plotW = width - padL - padR;
+  const plotH = height - padT - padB;
+
+  const defined = points.filter((p) => p.hitRate !== null) as Array<
+    { ts: number; hitRate: number }
+  >;
+  if (points.length === 0 || defined.length === 0) {
+    return `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" width="${width}" height="${height}" fill="#0b1020" rx="10" />
+      <text x="${width / 2}" y="${
+      height / 2
+    }" fill="#cbd5e1" font-family="ui-sans-serif,system-ui" font-size="14" text-anchor="middle">
+        Not enough data yet
+      </text>
+    </svg>`;
+  }
+
+  const minTs = points[0].ts;
+  const maxTs = points[points.length - 1].ts || (minTs + 1);
+
+  const x = (ts: number) =>
+    padL + ((ts - minTs) / Math.max(1, maxTs - minTs)) * plotW;
+  const y = (hr: number) => padT + (1 - Math.max(0, Math.min(1, hr))) * plotH;
+
+  // Build a path, breaking on nulls
+  let d = '';
+  let penDown = false;
+  for (const p of points) {
+    if (p.hitRate === null) {
+      penDown = false;
+      continue;
+    }
+    const px = x(p.ts);
+    const py = y(p.hitRate);
+    d += `${penDown ? ' L' : ' M'}${px.toFixed(2)} ${py.toFixed(2)}`;
+    penDown = true;
+  }
+
+  // Use ISO 8601 UTC - client handles localization
+  const startLabel = new Date(minTs).toISOString().slice(11, 16);
+  const endLabel = new Date(maxTs).toISOString().slice(11, 16);
+
+  return `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">
+    <rect x="0" y="0" width="${width}" height="${height}" fill="#0b1020" rx="10" />
+    <g opacity="0.25" stroke="#94a3b8">
+      <line x1="${padL}" y1="${padT}" x2="${width - padR}" y2="${padT}" />
+      <line x1="${padL}" y1="${padT + plotH / 2}" x2="${width - padR}" y2="${
+    padT + plotH / 2
+  }" />
+      <line x1="${padL}" y1="${padT + plotH}" x2="${width - padR}" y2="${
+    padT + plotH
+  }" />
+    </g>
+
+    <g fill="#cbd5e1" font-family="ui-sans-serif,system-ui" font-size="12">
+      <text x="10" y="${padT + 4}">100%</text>
+      <text x="14" y="${padT + plotH / 2 + 4}">50%</text>
+      <text x="18" y="${padT + plotH + 4}">0%</text>
+
+      <text x="${padL}" y="${height - 10}">${startLabel}</text>
+      <text x="${width - padR}" y="${
+    height - 10
+  }" text-anchor="end">${endLabel}</text>
+    </g>
+
+    <path d="${d}" fill="none" stroke="#60a5fa" stroke-width="2.5" />
+  </svg>`;
+}
+
+// deno-lint-ignore no-explicit-any
+export function registerMetricsRoutes(app: Hono<AppEnv>, auth: () => any) {
+  // Conditionally apply auth based on METRICS_AUTH env var (default: true)
+  const metricsAuth = Deno.env.get('METRICS_AUTH')?.toLowerCase() !== 'false';
+
+  // JSON time series
+  // deno-lint-ignore no-explicit-any
+  const jsonHandler = (c: Context<AppEnv, any>) => {
+    const now = Date.now();
+    const windowMs = parseDurationMs(c.req.query('window'), 6 * 60 * 60_000); // 6h
+    const bucketMs = parseDurationMs(c.req.query('bucket'), 60_000); // 1m
+
+    const computed = computeHitRateSeries(now, windowMs, bucketMs);
+
+    return c.json({
+      window: {
+        start: new Date(computed.start).toISOString(),
+        end: new Date(computed.end).toISOString(),
+        bucketMs: computed.bucketMs,
+      },
+      totals: computed.totals,
+      series: computed.points.map((p) => ({
+        ts: new Date(p.ts).toISOString(),
+        hits: p.hits,
+        misses: p.misses,
+        requests: p.requests,
+        hitRate: p.hitRate,
+      })),
+    });
+  };
+
+  // Tiny HTML chart (inline SVG)
+  // deno-lint-ignore no-explicit-any
+  const chartHandler = (c: Context<AppEnv, any>) => {
+    const now = Date.now();
+    const windowMs = parseDurationMs(c.req.query('window'), 6 * 60 * 60_000);
+    const bucketMs = parseDurationMs(c.req.query('bucket'), 60_000);
+
+    const computed = computeHitRateSeries(now, windowMs, bucketMs);
+    const svg = renderHitRateSvg(
+      computed.points.map((p) => ({ ts: p.ts, hitRate: p.hitRate })),
+    );
+
+    const title = `NX Cache hit rate (${formatPct(computed.totals.hitRate)})`;
+
+    const html = `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(title)}</title>
+</head>
+<body style="margin:0;padding:18px;background:#020617;color:#e2e8f0;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto;">
+  <div style="max-width:760px;margin:0 auto;">
+    <div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;margin-bottom:10px;">
+      <div>
+        <div style="font-size:16px;font-weight:600;">${escapeHtml(title)}</div>
+        <div style="font-size:12px;color:#94a3b8;">
+          window=${escapeHtml(String(c.req.query('window') ?? '6h'))}, bucket=${
+      escapeHtml(String(c.req.query('bucket') ?? '1m'))
+    }
+        </div>
+      </div>
+      <div style="text-align:right;font-size:12px;color:#94a3b8;">
+        <div>hits: ${computed.totals.hits}</div>
+        <div>misses: ${computed.totals.misses}</div>
+        <div>req: ${computed.totals.requests}</div>
+      </div>
+    </div>
+
+    ${svg}
+
+    <div style="margin-top:10px;font-size:12px;color:#94a3b8;">Refresh the page to update.</div>
+  </div>
+</body>
+</html>`;
+
+    return new Response(html, {
+      status: 200,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  };
+
+  if (metricsAuth) {
+    app.get('/v1/metrics/json', auth(), jsonHandler);
+    app.get('/v1/metrics/chart', auth(), chartHandler);
+  } else {
+    app.get('/v1/metrics/json', jsonHandler);
+    app.get('/v1/metrics/chart', chartHandler);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,16 @@
+import type { S3Client } from '@aws-sdk/client-s3';
+
+export type AppEnv = {
+  Bindings: {
+    NX_CACHE_ACCESS_TOKEN: string;
+    AWS_REGION: string;
+    AWS_ACCESS_KEY_ID: string;
+    AWS_SECRET_ACCESS_KEY: string;
+    S3_BUCKET_NAME: string;
+    S3_ENDPOINT_URL: string;
+    METRICS_AUTH: string;
+  };
+  Variables: {
+    s3: S3Client;
+  };
+};


### PR DESCRIPTION
Closes #3 

Current implementation:
- In memory metrics. Keeps count over time, but does not persist/after container reboot for retrieval (TODO)
- Default metric window is 6h (TODO: extend dynamically (30m, 1h, 3h, 1d, etc.). Best implemented after persisted metrics.)
- Metrics endpoints are not auth-protected. (TODO: use env vars to determine feature)
- Env var (TIMEZONE) used to display chart start/end timestamps

Example (chart):
<img width="868" height="267" alt="image" src="https://github.com/user-attachments/assets/e808a08b-582e-438a-8d10-6f6be3358398" />

Update 2026-05-13:

feat: add cache hit rate metrics with configurable auth
- Add metrics endpoints for cache hit/miss tracking:
  - GET /v1/metrics/json - JSON time series data
  - GET /v1/metrics/chart - HTML page with inline SVG chart
  - Both support ?window and ?bucket query params

- Add METRICS_AUTH env var (default: true)
  - Set to 'false' to disable auth on metrics endpoints

- Refactor to modular architecture:
  - Extract shared AppEnv type to src/types.ts
  - Separate route modules (cache.ts, metrics.ts)

- Remove date-fns-tz dependency
  - All timestamps now ISO 8601 UTC
  - Client handles localization

- Metrics are in-memory, reset on restart
  - S3 persistence planned for future version

- Update CLAUDE.md and README.md with metrics documentation
