### PR TITLE
feat(local-cache): added optional local filesystem caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Deno-based server implementation of the Nx Custom Self-Hosted Remote Cache
 specification. This server provides a caching layer for Nx build outputs using
-Amazon S3 as the storage backend.
+either Amazon S3 or the local filesystem as the storage backend.
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/-bmO7p?referralCode=73cYCO)
 
@@ -15,7 +15,7 @@ and provides a production-ready solution for self-hosting your Nx remote cache.
 ## Features
 
 - Implements the Nx custom remote cache specification
-- Uses Amazon S3 for storage
+- Pluggable storage backends: Amazon S3 (default) or local filesystem
 - Secure authentication using Bearer tokens
 - Efficient file streaming
 - Production-ready implementation
@@ -24,37 +24,67 @@ and provides a production-ready solution for self-hosting your Nx remote cache.
 ## Prerequisites
 
 - [Deno](https://deno.land/) installed on your system
-- S3 compatible storage
+- S3-compatible storage (when using the S3 backend)
 
 ## Environment Variables
 
-The following environment variables are required:
+### Common
 
-```env
-AWS_REGION=your-aws-region
-AWS_ACCESS_KEY_ID=your-access-key
-AWS_SECRET_ACCESS_KEY=your-secret-key
-S3_BUCKET_NAME=your-bucket-name
-S3_ENDPOINT_URL=your-s3-endpoint-url
-NX_CACHE_ACCESS_TOKEN=your-secure-token
-PORT=3000  # Optional, defaults to 3000
-```
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `NX_CACHE_ACCESS_TOKEN` | Yes | — | Bearer token used to authenticate cache requests |
+| `NX_CACHE_BACKEND` | No | `s3` | Storage backend to use: `s3` or `filesystem` |
+| `PORT` | No | `3000` | Port the server listens on |
+
+### S3 backend (default)
+
+Required when `NX_CACHE_BACKEND=s3` (or unset):
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `AWS_REGION` | Yes | — | AWS region (e.g. `us-east-1`) |
+| `AWS_ACCESS_KEY_ID` | Yes | — | AWS / MinIO access key |
+| `AWS_SECRET_ACCESS_KEY` | Yes | — | AWS / MinIO secret key |
+| `S3_BUCKET_NAME` | Yes | `nx-cloud` | S3 bucket to store cache artifacts in |
+| `S3_ENDPOINT_URL` | No | — | Custom S3-compatible endpoint (e.g. MinIO) |
+
+### Filesystem backend
+
+Used when `NX_CACHE_BACKEND=filesystem`:
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `NX_LOCAL_CACHE_DIR` | No | `/tmp/nx-cache` | Directory where cache artifacts are stored |
 
 ## Installation
 
 ### Using Docker
 
-The easiest way to run the server is using the official Docker image:
+The easiest way to run the server is using the official Docker image.
+
+**S3 backend:**
 
 ```bash
 docker pull ghcr.io/ikatsuba/nx-cache-server:latest
 docker run -p 3000:3000 \
+  -e NX_CACHE_ACCESS_TOKEN=your-secure-token \
   -e AWS_REGION=your-aws-region \
   -e AWS_ACCESS_KEY_ID=your-access-key \
   -e AWS_SECRET_ACCESS_KEY=your-secret-key \
   -e S3_BUCKET_NAME=your-bucket-name \
   -e S3_ENDPOINT_URL=your-s3-endpoint-url \
+  ghcr.io/ikatsuba/nx-cache-server:latest
+```
+
+**Filesystem backend:**
+
+```bash
+docker pull ghcr.io/ikatsuba/nx-cache-server:latest
+docker run -p 3000:3000 \
   -e NX_CACHE_ACCESS_TOKEN=your-secure-token \
+  -e NX_CACHE_BACKEND=filesystem \
+  -e NX_LOCAL_CACHE_DIR=/cache \
+  -v /path/on/host:/cache \
   ghcr.io/ikatsuba/nx-cache-server:latest
 ```
 

--- a/deno.json
+++ b/deno.json
@@ -12,9 +12,9 @@
     "singleQuote": true
   },
   "tasks": {
-    "start": "deno run --allow-env --allow-net --allow-sys --allow-read --env-file=.env src/index.ts",
-    "dev": "deno run --watch --allow-env --allow-net --allow-sys --allow-read --env-file=.env.local src/index.ts",
-    "test": "deno test --allow-env --allow-net --allow-sys --allow-read --env-file=.env.local src/**/*.test.ts",
+    "start": "deno run --allow-env --allow-net --allow-sys --allow-read --allow-write --env-file=.env src/index.ts",
+    "dev": "deno run --watch --allow-env --allow-net --allow-sys --allow-read --allow-write --env-file=.env.local src/index.ts",
+    "test": "deno test --allow-env --allow-net --allow-sys --allow-read --allow-write --env-file=.env.local src/**/*.test.ts",
     "e2e": "deno test --allow-env --allow-net --allow-sys --allow-read --allow-write --allow-run --env-file=.env.local e2e/**/*.test.ts",
     "wait-for-bucket": "deno run --allow-net --allow-env --env-file=.env.local --allow-sys --allow-read scripts/wait-for-bucket.ts"
   }

--- a/deno.lock
+++ b/deno.lock
@@ -23,6 +23,7 @@
     "npm:@aws-sdk/client-s3@*": "3.779.0",
     "npm:@aws-sdk/client-s3@^3.779.0": "3.779.0",
     "npm:@aws-sdk/s3-request-presigner@^3.779.0": "3.779.0",
+    "npm:deno@^2.7.9": "2.7.9",
     "npm:hono@^4.7.5": "4.7.5"
   },
   "jsr": {
@@ -645,6 +646,36 @@
         "tslib"
       ]
     },
+    "@deno/darwin-arm64@2.7.9": {
+      "integrity": "sha512-9EslB4tupeeXTNPne9Hsyrc5fFfOKp9nZmMBLcZMotLd5/u1siBuczNLKJXab+v/Vn4ZuAgpyppaox0nxej6Wg==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@deno/darwin-x64@2.7.9": {
+      "integrity": "sha512-Dr9pkY84TRHwVh5Q/X2ZhXx1LBdfSKPJ4eSYSp93dSWq6x62v5vMobmcWep1j4fiEkw57OgZapGYX8JQHJj3bA==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@deno/linux-arm64-glibc@2.7.9": {
+      "integrity": "sha512-EXciAZlRiuA6j+wIEvC8+NcZD4eLTLeDHY/9S83S+TkUHRpZcqwyCY0i9BcR07mZFgZRSVaRNpL7DkGOxAxguw==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@deno/linux-x64-glibc@2.7.9": {
+      "integrity": "sha512-ErOk3RucGPnDpoXnLrYrnhYOiMmZ7qhogDTolJZX9Nhhch96R9OLsiSlb7Tp+L9i541pdfPVcBv31cUv8hSqKA==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@deno/win32-arm64@2.7.9": {
+      "integrity": "sha512-b/A7/+yQPb8F2JGthm/WYsPxXt5Z12SneHC+JJFlW8XoC2NzXwK+UAR7s8TICHSDqGtzywYhN1edZe2gY9O0hQ==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@deno/win32-x64@2.7.9": {
+      "integrity": "sha512-bUr8A/WaB9V+uX2JaUliU8E2ch0v7XLycTP4EbXUtipI5+pymwXgsyvWYyRHmWxUyjArdq6vW0juh0KxJ8u7YQ==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
     "@smithy/abort-controller@4.0.2": {
       "integrity": "sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==",
       "dependencies": [
@@ -1085,6 +1116,19 @@
     "bowser@2.11.0": {
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
+    "deno@2.7.9": {
+      "integrity": "sha512-sEQ/oEp8mOPAhplbR6tR/T8moNMlOtWhMQFS05wYpMs2+UQVI3E30104tF17jWW4duTysKk47mT4+tV7fiaCvw==",
+      "optionalDependencies": [
+        "@deno/darwin-arm64",
+        "@deno/darwin-x64",
+        "@deno/linux-arm64-glibc",
+        "@deno/linux-x64-glibc",
+        "@deno/win32-arm64",
+        "@deno/win32-x64"
+      ],
+      "scripts": true,
+      "bin": true
+    },
     "fast-xml-parser@4.4.1": {
       "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "dependencies": [
@@ -1115,6 +1159,11 @@
       "npm:@aws-sdk/client-s3@^3.779.0",
       "npm:@aws-sdk/s3-request-presigner@^3.779.0",
       "npm:hono@^4.7.5"
-    ]
+    ],
+    "packageJson": {
+      "dependencies": [
+        "npm:deno@^2.7.9"
+      ]
+    }
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -13,16 +13,46 @@ async function makeRequest(
       'Authorization': 'Bearer test-token',
       ...headers,
     },
-    body,
+    body: body as BodyInit | null | undefined,
   });
 
   return await app.fetch(req, {
     NX_CACHE_ACCESS_TOKEN: 'test-token',
+    NX_CACHE_BACKEND: 's3',
+    NX_LOCAL_CACHE_DIR: '',
     AWS_REGION: 'us-east-1',
     AWS_ACCESS_KEY_ID: 'minio',
     AWS_SECRET_ACCESS_KEY: 'minio123',
     S3_BUCKET_NAME: 'nx-cloud',
     S3_ENDPOINT_URL: 'http://localhost:9000',
+  });
+}
+
+async function makeFilesystemRequest(
+  method: string,
+  path: string,
+  cacheDir: string,
+  headers: Record<string, string> = {},
+  body?: Uint8Array,
+) {
+  const req = new Request(`http://localhost${path}`, {
+    method,
+    headers: {
+      'Authorization': 'Bearer test-token',
+      ...headers,
+    },
+    body: body as BodyInit | null | undefined,
+  });
+
+  return await app.fetch(req, {
+    NX_CACHE_ACCESS_TOKEN: 'test-token',
+    NX_CACHE_BACKEND: 'filesystem',
+    NX_LOCAL_CACHE_DIR: cacheDir,
+    AWS_REGION: '',
+    AWS_ACCESS_KEY_ID: '',
+    AWS_SECRET_ACCESS_KEY: '',
+    S3_BUCKET_NAME: '',
+    S3_ENDPOINT_URL: '',
   });
 }
 
@@ -97,4 +127,84 @@ Deno.test('GET /v1/cache/{hash} - Not Found', async () => {
   assertEquals(response.status, 404);
   const body = await response.text();
   assertEquals(body, 'The record was not found');
+});
+
+Deno.test('Filesystem - PUT /v1/cache/{hash} - Success', async () => {
+  const cacheDir = await Deno.makeTempDir();
+  try {
+    const hash = crypto.randomUUID();
+    const response = await makeFilesystemRequest(
+      'PUT',
+      `/v1/cache/${hash}`,
+      cacheDir,
+      { 'Content-Type': 'application/octet-stream' },
+      Deno.readFileSync('./src/index.ts'),
+    );
+
+    assertEquals(response.status, 202);
+    assertEquals(await response.text(), 'Successfully uploaded');
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true });
+  }
+});
+
+Deno.test('Filesystem - PUT /v1/cache/{hash} - Conflict', async () => {
+  const cacheDir = await Deno.makeTempDir();
+  try {
+    const hash = crypto.randomUUID();
+    const data = Deno.readFileSync('./src/index.ts');
+
+    await makeFilesystemRequest('PUT', `/v1/cache/${hash}`, cacheDir, {}, data);
+    const response = await makeFilesystemRequest(
+      'PUT',
+      `/v1/cache/${hash}`,
+      cacheDir,
+      {},
+      data,
+    );
+
+    assertEquals(response.status, 409);
+    assertEquals(await response.text(), 'Cannot override an existing record');
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true });
+  }
+});
+
+Deno.test('Filesystem - GET /v1/cache/{hash} - Success', async () => {
+  const cacheDir = await Deno.makeTempDir();
+  try {
+    const hash = crypto.randomUUID();
+    const data = Deno.readFileSync('./src/index.ts');
+
+    await makeFilesystemRequest('PUT', `/v1/cache/${hash}`, cacheDir, {}, data);
+    const response = await makeFilesystemRequest(
+      'GET',
+      `/v1/cache/${hash}`,
+      cacheDir,
+    );
+
+    assertEquals(response.status, 200);
+    assertExists(response.headers.get('content-type'));
+    const body = await response.arrayBuffer();
+    assertEquals(new Uint8Array(body), data);
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true });
+  }
+});
+
+Deno.test('Filesystem - GET /v1/cache/{hash} - Not Found', async () => {
+  const cacheDir = await Deno.makeTempDir();
+  try {
+    const hash = crypto.randomUUID();
+    const response = await makeFilesystemRequest(
+      'GET',
+      `/v1/cache/${hash}`,
+      cacheDir,
+    );
+
+    assertEquals(response.status, 404);
+    assertEquals(await response.text(), 'The record was not found');
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true });
+  }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,110 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { join } from '@std/path/join';
+
+interface StorageBackend {
+  exists(key: string): Promise<boolean>;
+  put(key: string, data: Uint8Array): Promise<void>;
+  get(key: string): Promise<Response>;
+}
+
+class S3Backend implements StorageBackend {
+  constructor(
+    private readonly client: S3Client,
+    private readonly bucket: string,
+  ) {}
+
+  async exists(key: string): Promise<boolean> {
+    try {
+      await this.client.send(
+        new HeadObjectCommand({ Bucket: this.bucket, Key: key }),
+      );
+      return true;
+    } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'NotFound') {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async put(key: string, data: Uint8Array): Promise<void> {
+    await this.client.send(
+      new PutObjectCommand({ Bucket: this.bucket, Key: key, Body: data }),
+    );
+  }
+
+  async get(key: string): Promise<Response> {
+    const command = new GetObjectCommand({ Bucket: this.bucket, Key: key });
+    const url = await getSignedUrl(this.client, command, { expiresIn: 18000 });
+    const response = await fetch(url);
+    if (!response.ok) {
+      console.error('Download error:', response.statusText);
+      await response.body?.cancel();
+      if (response.status === 404) {
+        return new Response('The record was not found', {
+          status: 404,
+          headers: { 'Content-Type': 'text/plain' },
+        });
+      }
+      return new Response('Access forbidden', {
+        status: 403,
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    }
+    return response;
+  }
+}
+
+class FilesystemBackend implements StorageBackend {
+  constructor(private readonly cacheDir: string) {}
+
+  private filePath(key: string): string {
+    return join(this.cacheDir, key);
+  }
+
+  async exists(key: string): Promise<boolean> {
+    try {
+      await Deno.stat(this.filePath(key));
+      return true;
+    } catch (error: unknown) {
+      if (error instanceof Deno.errors.NotFound) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async put(key: string, data: Uint8Array): Promise<void> {
+    await Deno.mkdir(this.cacheDir, { recursive: true });
+    await Deno.writeFile(this.filePath(key), data);
+  }
+
+  async get(key: string): Promise<Response> {
+    try {
+      const data = await Deno.readFile(this.filePath(key));
+      return new Response(data, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      });
+    } catch (error: unknown) {
+      if (error instanceof Deno.errors.NotFound) {
+        return new Response('The record was not found', {
+          status: 404,
+          headers: { 'Content-Type': 'text/plain' },
+        });
+      }
+      throw error;
+    }
+  }
+}
 
 export const app = new Hono<{
   Bindings: {
     NX_CACHE_ACCESS_TOKEN: string;
+    NX_CACHE_BACKEND: string;
+    NX_LOCAL_CACHE_DIR: string;
     AWS_REGION: string;
     AWS_ACCESS_KEY_ID: string;
     AWS_SECRET_ACCESS_KEY: string;
@@ -20,14 +120,19 @@ export const app = new Hono<{
     S3_ENDPOINT_URL: string;
   };
   Variables: {
-    s3: S3Client;
+    storage: StorageBackend;
   };
 }>();
 
 app.use(async (c, next) => {
-  c.set(
-    's3',
-    new S3Client({
+  const backend = c.env.NX_CACHE_BACKEND || 's3';
+  let storage: StorageBackend;
+
+  if (backend === 'filesystem') {
+    const cacheDir = c.env.NX_LOCAL_CACHE_DIR || '/tmp/nx-cache';
+    storage = new FilesystemBackend(cacheDir);
+  } else {
+    const client = new S3Client({
       region: c.env.AWS_REGION,
       endpoint: c.env.S3_ENDPOINT_URL,
       credentials: {
@@ -35,9 +140,11 @@ app.use(async (c, next) => {
         secretAccessKey: c.env.AWS_SECRET_ACCESS_KEY,
       },
       forcePathStyle: true,
-    }),
-  );
+    });
+    storage = new S3Backend(client, c.env.S3_BUCKET_NAME);
+  }
 
+  c.set('storage', storage);
   await next();
 });
 
@@ -75,40 +182,26 @@ app.get('/health', () => {
 app.put('/v1/cache/:hash', auth(), async (c) => {
   try {
     const hash = c.req.param('hash');
+    const storage = c.get('storage');
 
     try {
-      await c.get('s3').send(
-        new HeadObjectCommand({
-          Bucket: c.env.S3_BUCKET_NAME,
-          Key: hash,
-        }),
-      );
-
-      return new Response('Cannot override an existing record', {
-        status: 409,
-        headers: { 'Content-Type': 'text/plain' },
-      });
-    } catch (error: unknown) {
-      if (error instanceof Error && error.name === 'NotFound') {
-        // Do nothing
-      } else {
-        console.error('Upload error:', error);
-        return new Response('Internal server error', {
-          status: 500,
+      const exists = await storage.exists(hash);
+      if (exists) {
+        return new Response('Cannot override an existing record', {
+          status: 409,
           headers: { 'Content-Type': 'text/plain' },
         });
       }
+    } catch (error: unknown) {
+      console.error('Upload error:', error);
+      return new Response('Internal server error', {
+        status: 500,
+        headers: { 'Content-Type': 'text/plain' },
+      });
     }
 
     const body = await c.req.arrayBuffer();
-
-    await c.get('s3').send(
-      new PutObjectCommand({
-        Bucket: c.env.S3_BUCKET_NAME,
-        Key: hash,
-        Body: new Uint8Array(body),
-      }),
-    );
+    await storage.put(hash, new Uint8Array(body));
 
     return new Response('Successfully uploaded', {
       status: 202,
@@ -126,37 +219,7 @@ app.put('/v1/cache/:hash', auth(), async (c) => {
 app.get('/v1/cache/:hash', auth(), async (c) => {
   try {
     const hash = c.req.param('hash');
-
-    const command = new GetObjectCommand({
-      Bucket: c.env.S3_BUCKET_NAME,
-      Key: hash,
-    });
-
-    const url = await getSignedUrl(c.get('s3'), command, {
-      expiresIn: 18000,
-    });
-
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      console.error('Download error:', response.statusText);
-
-      await response.body?.cancel();
-
-      if (response.status === 404) {
-        return new Response('The record was not found', {
-          status: 404,
-          headers: { 'Content-Type': 'text/plain' },
-        });
-      }
-
-      return new Response('Access forbidden', {
-        status: 403,
-        headers: { 'Content-Type': 'text/plain' },
-      });
-    }
-
-    return response;
+    return await c.get('storage').get(hash);
   } catch (error: unknown) {
     if (error instanceof Error && error.name === 'NoSuchKey') {
       return new Response('The record was not found', {
@@ -179,6 +242,8 @@ if (import.meta.main) {
   Deno.serve({ port }, (req) =>
     app.fetch(req, {
       NX_CACHE_ACCESS_TOKEN: Deno.env.get('NX_CACHE_ACCESS_TOKEN'),
+      NX_CACHE_BACKEND: Deno.env.get('NX_CACHE_BACKEND') || 's3',
+      NX_LOCAL_CACHE_DIR: Deno.env.get('NX_LOCAL_CACHE_DIR') || '/tmp/nx-cache',
       AWS_REGION: Deno.env.get('AWS_REGION') || 'us-east-1',
       AWS_ACCESS_KEY_ID: Deno.env.get('AWS_ACCESS_KEY_ID'),
       AWS_SECRET_ACCESS_KEY: Deno.env.get('AWS_SECRET_ACCESS_KEY'),


### PR DESCRIPTION
# Add filesystem storage backend

S3 is great for production, but it's overkill when you're running the cache server locally or in a CI environment where you just want artifacts written to disk. This PR adds a local filesystem backend as an alternative to S3.

## What changed

A `StorageBackend` interface now sits between the route handlers and the underlying storage, with two implementations: `S3Backend` (the existing behaviour) and `FilesystemBackend`. The route handlers themselves got noticeably simpler as a result — they no longer care about S3-specific details.

Two new environment variables control the filesystem backend:

- `NX_CACHE_BACKEND` — set to `filesystem` to opt in; defaults to `s3` so nothing changes for existing deployments
- `NX_LOCAL_CACHE_DIR` — where files are written; defaults to `/tmp/nx-cache`

## Testing

Added four unit tests for the filesystem backend (PUT success, PUT conflict/idempotency, GET success, GET not found). Each test spins up an isolated temp directory and cleans up after itself, so no external dependencies are needed to run them.

The `--allow-write` Deno permission flag was also missing from the `start`, `dev`, and `test` tasks — added that too, since the filesystem backend obviously needs it.

## Notes for reviewers

- The S3 path is unchanged — `S3Backend` is just the same logic wrapped in the interface
- The Docker example in the README shows mounting a volume when using the filesystem backend, which is probably the most common use case
