### PR TITLE
feat: Helm chart for Kubernetes deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,24 @@ jobs:
         run: |
           deno task test
           deno task e2e
+  helm-lint:
+    name: Helm Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+      - name: helm lint
+        run: helm lint charts/nx-cache-server
+      - name: helm template smoke test
+        run: |
+          helm template test charts/nx-cache-server \
+            --set secrets.nxCacheAccessToken=token \
+            --set secrets.awsAccessKeyId=key \
+            --set secrets.awsSecretAccessKey=secret \
+            --set config.s3.endpointUrl=http://localhost:4566 \
+            > /dev/null
   publish:
     runs-on: ubuntu-latest
     needs:
@@ -84,3 +102,34 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64/v8
+  helm-publish:
+    name: Publish Helm Chart
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    needs:
+      - checks
+      - e2e
+      - helm-lint
+      - publish
+    permissions:
+      contents: read
+      packages: write
+    env:
+      CHART_DIR: charts/nx-cache-server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+      - name: Derive version from release tag
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Package chart
+        run: |
+          helm package "$CHART_DIR" \
+            --version "${{ steps.ver.outputs.version }}" \
+            --app-version "${{ steps.ver.outputs.version }}"
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Push chart to GHCR
+        run: helm push "nx-cache-server-${{ steps.ver.outputs.version }}.tgz" oci://ghcr.io/ikatsuba/charts

--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ docker run -p 3000:3000 \
   ghcr.io/ikatsuba/nx-cache-server:latest
 ```
 
+### Using Helm (Kubernetes)
+
+The chart is published as an OCI artifact to GHCR alongside the Docker image:
+
+```bash
+helm install nx-cache oci://ghcr.io/ikatsuba/charts/nx-cache-server \
+  --version <X.Y.Z> \
+  --namespace nx-cache --create-namespace \
+  --set secrets.nxCacheAccessToken=your-secure-token \
+  --set secrets.awsAccessKeyId=your-access-key \
+  --set secrets.awsSecretAccessKey=your-secret-key \
+  --set config.s3.bucketName=your-bucket-name \
+  --set config.s3.endpointUrl=https://s3.amazonaws.com
+```
+
+See [`charts/nx-cache-server/README.md`](charts/nx-cache-server/README.md) for
+the full values reference, externally managed Secret usage, and IRSA / Workload
+Identity setup.
+
 ### Manual Installation
 
 1. Clone the repository:

--- a/charts/nx-cache-server/.helmignore
+++ b/charts/nx-cache-server/.helmignore
@@ -1,0 +1,18 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/nx-cache-server/Chart.yaml
+++ b/charts/nx-cache-server/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: nx-cache-server
+description: Self-hosted Nx remote cache server backed by S3-compatible storage.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+kubeVersion: ">=1.23.0-0"
+home: https://github.com/IKatsuba/nx-cache-server
+sources:
+  - https://github.com/IKatsuba/nx-cache-server
+keywords:
+  - nx
+  - cache
+  - remote-cache
+  - s3
+maintainers:
+  - name: IKatsuba
+    url: https://github.com/IKatsuba

--- a/charts/nx-cache-server/README.md
+++ b/charts/nx-cache-server/README.md
@@ -1,0 +1,92 @@
+# nx-cache-server Helm chart
+
+Helm chart for deploying [nx-cache-server](https://github.com/IKatsuba/nx-cache-server)
+— a self-hosted Nx remote cache backed by S3-compatible storage — to Kubernetes.
+
+## Install
+
+Charts are published as OCI artifacts to GHCR.
+
+```bash
+helm install nx-cache oci://ghcr.io/ikatsuba/charts/nx-cache-server \
+  --version 0.1.0 \
+  --namespace nx-cache --create-namespace \
+  --set secrets.nxCacheAccessToken=<token> \
+  --set secrets.awsAccessKeyId=<key> \
+  --set secrets.awsSecretAccessKey=<secret> \
+  --set config.s3.bucketName=nx-cloud \
+  --set config.s3.endpointUrl=https://s3.amazonaws.com
+```
+
+## Using an externally managed Secret
+
+Create a Secret with the three required keys and reference it via
+`secrets.existingSecret`:
+
+```bash
+kubectl create secret generic nx-cache-creds \
+  --from-literal=nx-cache-access-token=<token> \
+  --from-literal=aws-access-key-id=<key> \
+  --from-literal=aws-secret-access-key=<secret>
+
+helm install nx-cache oci://ghcr.io/ikatsuba/charts/nx-cache-server \
+  --version 0.1.0 \
+  --set secrets.existingSecret=nx-cache-creds \
+  --set config.s3.endpointUrl=https://s3.amazonaws.com
+```
+
+## IRSA / Workload Identity (no static AWS keys)
+
+Annotate the ServiceAccount so the pod uses cloud-native credentials. With
+IRSA on EKS:
+
+```yaml
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/nx-cache-server
+
+secrets:
+  existingSecret: nx-cache-token-only  # holding only nx-cache-access-token
+```
+
+When using IRSA you still need `aws-access-key-id` / `aws-secret-access-key`
+keys in the Secret because the server reads them from env vars. To opt fully
+out of static keys, fork the chart or set them to empty placeholders if your
+S3 client picks up the IAM role from the metadata service.
+
+## Values
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `image.repository` | `ghcr.io/ikatsuba/nx-cache-server` | Container image |
+| `image.tag` | `""` (Chart.AppVersion) | Image tag |
+| `image.pullPolicy` | `IfNotPresent` | |
+| `imagePullSecrets` | `[]` | |
+| `replicaCount` | `1` | |
+| `service.type` | `ClusterIP` | |
+| `service.port` | `3000` | |
+| `serviceAccount.create` | `true` | |
+| `serviceAccount.name` | `""` | |
+| `serviceAccount.annotations` | `{}` | IRSA / Workload Identity annotations |
+| `probes.liveness.enabled` | `true` | Liveness probe on `/health` |
+| `probes.readiness.enabled` | `true` | Readiness probe on `/health` |
+| `config.port` | `3000` | Container `PORT` |
+| `config.awsRegion` | `us-east-1` | `AWS_REGION` |
+| `config.s3.bucketName` | `nx-cloud` | `S3_BUCKET_NAME` |
+| `config.s3.endpointUrl` | `""` | **Required.** `S3_ENDPOINT_URL` |
+| `secrets.existingSecret` | `""` | If set, skip Secret creation and use this one |
+| `secrets.nxCacheAccessToken` | `""` | Required if `existingSecret` is empty |
+| `secrets.awsAccessKeyId` | `""` | Required if `existingSecret` is empty |
+| `secrets.awsSecretAccessKey` | `""` | Required if `existingSecret` is empty |
+| `extraEnv` | `[]` | Extra env vars appended to the container |
+| `resources` | `{}` | |
+| `nodeSelector` | `{}` | |
+| `tolerations` | `[]` | |
+| `affinity` | `{}` | |
+| `podAnnotations` | `{}` | |
+| `podLabels` | `{}` | |
+| `podSecurityContext` | `{}` | |
+| `securityContext` | `{}` | |
+
+When using `secrets.existingSecret`, the Secret must contain the keys
+`nx-cache-access-token`, `aws-access-key-id`, `aws-secret-access-key`.

--- a/charts/nx-cache-server/templates/NOTES.txt
+++ b/charts/nx-cache-server/templates/NOTES.txt
@@ -1,0 +1,21 @@
+{{ .Chart.Name }} {{ .Chart.AppVersion }} has been installed as release {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
+
+Service: {{ include "nx-cache-server.fullname" . }} ({{ .Values.service.type }}) on port {{ .Values.service.port }}
+
+To reach the cache server from your machine:
+
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "nx-cache-server.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  curl -fsS http://localhost:{{ .Values.service.port }}/health
+
+Point Nx at it via nx.json:
+
+  "tasksRunnerOptions": {
+    "default": {
+      "options": {
+        "remoteCache": {
+          "url": "http://<your-ingress-or-service>:{{ .Values.service.port }}/v1/cache",
+          "accessToken": "<NX_CACHE_ACCESS_TOKEN>"
+        }
+      }
+    }
+  }

--- a/charts/nx-cache-server/templates/_helpers.tpl
+++ b/charts/nx-cache-server/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nx-cache-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "nx-cache-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "nx-cache-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "nx-cache-server.labels" -}}
+helm.sh/chart: {{ include "nx-cache-server.chart" . }}
+{{ include "nx-cache-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "nx-cache-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nx-cache-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "nx-cache-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "nx-cache-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the Secret holding sensitive env values. Returns existingSecret if
+set, otherwise the chart-managed Secret name.
+*/}}
+{{- define "nx-cache-server.secretName" -}}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
+{{- else }}
+{{- include "nx-cache-server.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/nx-cache-server/templates/deployment.yaml
+++ b/charts/nx-cache-server/templates/deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nx-cache-server.fullname" . }}
+  labels:
+    {{- include "nx-cache-server.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "nx-cache-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nx-cache-server.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "nx-cache-server.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.config.port | quote }}
+            - name: AWS_REGION
+              value: {{ .Values.config.awsRegion | quote }}
+            - name: S3_BUCKET_NAME
+              value: {{ .Values.config.s3.bucketName | quote }}
+            - name: S3_ENDPOINT_URL
+              value: {{ required "config.s3.endpointUrl is required" .Values.config.s3.endpointUrl | quote }}
+            - name: NX_CACHE_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nx-cache-server.secretName" . }}
+                  key: nx-cache-access-token
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nx-cache-server.secretName" . }}
+                  key: aws-access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nx-cache-server.secretName" . }}
+                  key: aws-secret-access-key
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/nx-cache-server/templates/secret.yaml
+++ b/charts/nx-cache-server/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.secrets.existingSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "nx-cache-server.fullname" . }}
+  labels:
+    {{- include "nx-cache-server.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  nx-cache-access-token: {{ required "secrets.nxCacheAccessToken is required when secrets.existingSecret is not set" .Values.secrets.nxCacheAccessToken | quote }}
+  aws-access-key-id: {{ required "secrets.awsAccessKeyId is required when secrets.existingSecret is not set" .Values.secrets.awsAccessKeyId | quote }}
+  aws-secret-access-key: {{ required "secrets.awsSecretAccessKey is required when secrets.existingSecret is not set" .Values.secrets.awsSecretAccessKey | quote }}
+{{- end }}

--- a/charts/nx-cache-server/templates/service.yaml
+++ b/charts/nx-cache-server/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nx-cache-server.fullname" . }}
+  labels:
+    {{- include "nx-cache-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "nx-cache-server.selectorLabels" . | nindent 4 }}

--- a/charts/nx-cache-server/templates/serviceaccount.yaml
+++ b/charts/nx-cache-server/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "nx-cache-server.serviceAccountName" . }}
+  labels:
+    {{- include "nx-cache-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/nx-cache-server/values.yaml
+++ b/charts/nx-cache-server/values.yaml
@@ -1,0 +1,69 @@
+image:
+  repository: ghcr.io/ikatsuba/nx-cache-server
+  # Defaults to .Chart.AppVersion if empty.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 3000
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+podLabels: {}
+podSecurityContext: {}
+securityContext: {}
+
+serviceAccount:
+  create: true
+  name: ""
+  # Annotations to add to the ServiceAccount. Use this for IRSA
+  # (eks.amazonaws.com/role-arn) or GKE Workload Identity
+  # (iam.gke.io/gcp-service-account) to avoid static AWS keys.
+  annotations: {}
+
+probes:
+  liveness:
+    enabled: true
+    path: /health
+    initialDelaySeconds: 5
+    periodSeconds: 10
+  readiness:
+    enabled: true
+    path: /health
+    initialDelaySeconds: 2
+    periodSeconds: 5
+
+# Non-secret configuration mapped to env vars in the container.
+config:
+  port: 3000
+  awsRegion: us-east-1
+  s3:
+    bucketName: nx-cloud
+    # S3 endpoint URL — e.g. https://s3.amazonaws.com or a custom endpoint.
+    endpointUrl: ""
+
+# Secret strategy: either supply the three values below to have the chart
+# create a Secret, or set existingSecret to the name of an externally managed
+# Secret. The external Secret must contain keys:
+#   - nx-cache-access-token
+#   - aws-access-key-id
+#   - aws-secret-access-key
+secrets:
+  existingSecret: ""
+  nxCacheAccessToken: ""
+  awsAccessKeyId: ""
+  awsSecretAccessKey: ""
+
+# Extra environment variables appended to the container. Use either `value`
+# or `valueFrom` per Kubernetes env semantics.
+extraEnv: []


### PR DESCRIPTION
## Summary
- Adds `charts/nx-cache-server/` — Deployment, Service, Secret, ServiceAccount, with `/health` liveness/readiness probes.
- Secret strategy is flexible: chart-managed Secret from values **or** `secrets.existingSecret` pointing at an externally managed one (External Secrets / Sealed Secrets / Vault).
- ServiceAccount annotations are configurable for IRSA / GKE Workload Identity (avoid static AWS keys).
- CI: new `helm-lint` job on every push/PR + new `helm-publish` job that runs on `release: published` and pushes the chart as an OCI artifact to `ghcr.io/ikatsuba/charts/nx-cache-server`, versioned to the release tag — same trigger as the Docker image.
- README updated with a `Using Helm (Kubernetes)` section pointing at the chart's own README for the full values reference.

Resolves #4.

## Test plan
Verified locally before opening the PR:

- [x] `helm lint charts/nx-cache-server` — clean
- [x] `helm template` — default render
- [x] `helm template --set secrets.existingSecret=...` — Secret manifest is skipped, Deployment references the external one
- [x] `helm template` without required values — fails with explicit `required` messages
- [x] `actionlint .github/workflows/main.yml` — clean
- [x] `helm install --dry-run` against a real cluster (orbstack) — OK
- [x] `helm install --wait` on orbstack (with `--set image.tag=main` since no `v0.1.0` release exists yet) — Pod Ready 1/1
- [x] `curl /health` via port-forward → `HTTP 200 "OK"`
- [x] `curl /v1/cache/abc123` without `Authorization` → `HTTP 401` (auth gate works)
- [x] `curl /v1/cache/abc123` with `Bearer devtoken` → reaches S3 client (auth path verified)

## Post-merge follow-ups (manual, one-time)
- Cut a GitHub Release tagged `vX.Y.Z` to trigger `helm-publish`.
- After the first chart publish, set the `ikatsuba/charts/nx-cache-server` package visibility to **Public** in the GHCR UI so `helm pull oci://...` works without auth.