### PR TITLE
fix(ci): exclude charts/ from deno fmt and lint

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -10,7 +10,11 @@
     "hono": "npm:hono@^4.7.5"
   },
   "fmt": {
-    "singleQuote": true
+    "singleQuote": true,
+    "exclude": ["charts/"]
+  },
+  "lint": {
+    "exclude": ["charts/"]
   },
   "tasks": {
     "start": "deno run --allow-env --allow-net --allow-sys --allow-read --env-file=.env src/index.ts",


### PR DESCRIPTION
## Summary
The v1.1.0 release workflow failed because `deno fmt --check` errors on the new Helm chart files:
- Templates contain `{{ }}` blocks that aren't valid YAML, so the parser rejects them.
- `Chart.yaml` uses `"..."`, which the project's `singleQuote: true` fmt rule rewrites to `'...'`.

Helm chart files shouldn't be subject to Deno conventions. Excluding `charts/` from both `fmt` and `lint` in `deno.json`.

## Test plan
- [x] `deno fmt --check` — clean
- [x] `deno lint` — clean
- [x] `helm lint charts/nx-cache-server` — still clean (unaffected)

## Follow-up
Once merged, the v1.1.0 release didn't manage to publish the chart (workflow failed before `helm-publish`). Options:
- Delete + recreate the v1.1.0 tag/release on the new main HEAD, **or**
- Cut a fresh v1.1.1 (simpler, no destructive ops, normal "broken release → patch" pattern).