### PR TITLE
fix(security): keep the git checkout out of the published image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Deny everything, then allow-list only what the runtime image needs.
+# Keeps `.git` (which carries the ephemeral CI checkout token in
+# `http.extraheader`), `.env*` files, tests and TLS fixtures out of the image.
+*
+
+!deno.json
+!deno.lock
+!src/index.ts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
@@ -32,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
@@ -45,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: azure/setup-helm@v4
         with:
           version: v3.16.2
@@ -71,6 +77,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -118,6 +126,8 @@ jobs:
       CHART_DIR: charts/nx-cache-server
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: azure/setup-helm@v4
         with:
           version: v3.16.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM denoland/deno:2.7.14
 
 WORKDIR /app
-COPY . .
+
+# Copy only the manifests first so dependency installation stays cached.
+COPY deno.json deno.lock ./
 RUN deno install
+
+# Copy only the server entrypoint — never the whole build context.
+COPY src/index.ts ./src/index.ts
 
 CMD ["deno", "task", "start"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest published release receives security fixes. Images are published
+to `ghcr.io/ikatsuba/nx-cache-server`; older tags are not patched.
+
+## Reporting a vulnerability
+
+Please do not open a public issue, a pull request, or a discussion for a
+suspected vulnerability.
+
+Report it through
+[GitHub private vulnerability reporting](https://github.com/IKatsuba/nx-cache-server/security/advisories/new),
+which is enabled for this repository. If that is not available to you, email
+<igor@katsuba.dev> instead.
+
+Helpful things to include, as far as you have them:
+
+- what an attacker can do, and what access they need to do it
+- the affected image tag, chart version, or commit
+- steps to reproduce, or the command output that shows the problem
+- any workaround you already found
+
+## What to expect
+
+- An acknowledgement within 5 days.
+- An assessment — whether the report is confirmed, and the severity — within 14
+  days.
+- A fix released before any public disclosure, coordinated with you on timing.
+- Credit in the advisory and the release notes, unless you prefer otherwise.
+
+This is a small project maintained in spare time, so these are honest targets
+rather than a contractual SLA. If a report goes unanswered past those windows, a
+nudge by email is welcome.
+
+## Scope
+
+In scope: this server, its Docker image, the Helm chart in `charts/`, and the
+release workflow.
+
+Out of scope: vulnerabilities in Nx itself, in your S3 provider, or in
+deployments that expose the server without `NX_CACHE_ACCESS_TOKEN` set.


### PR DESCRIPTION
## Problem

The `Dockerfile` used `COPY . .` and the repository had no `.dockerignore`, so the whole build context landed in an image layer — including `.git`.

`actions/checkout` defaults to `persist-credentials: true`, which writes the job's ephemeral `GITHUB_TOKEN` into `.git/config`:

```
[http "https://github.com/"]
	extraheader = AUTHORIZATION: basic <base64 x-access-token:TOKEN>
```

So every published image carried that token, readable by anyone who pulled the image while the token was still valid — a window running from the image push to the end of the publish job. In that window the token grants `packages: write` on `ghcr.io/ikatsuba/*` (the `publish` job scopes its permissions, so it is not the full default set).

Confirmed present in `ghcr.io/ikatsuba/nx-cache-server:main`. Tokens in already-published images are expired, so there is nothing to rotate.

The same `COPY . .` also shipped `.env.local`, the test suites, `.github/`, editor configs, and — on any build after #11 — the TLS test fixtures including `src/fixtures/tls/key.pem`.

## Fix

- **`Dockerfile`** — copy only `deno.json`/`deno.lock` (ahead of `deno install`, which also keeps the dependency layer cached) and `src/index.ts`.
- **`.dockerignore`** (new) — deny-all plus an allow-list of those same paths, so a future `COPY . .` cannot reintroduce the leak.
- **`.github/workflows/main.yml`** — `persist-credentials: false` on all five checkout steps. No job needs git credentials after checkout; `helm-publish` authenticates to GHCR explicitly.

## Verification

- Built the image: `/app` contains only `deno.json`, `deno.lock`, `src/index.ts`. A `grep` across the filesystem for `extraheader` and the test AWS key returns nothing.
- Container starts and `GET /health` returns `200`.
- `deno fmt --check` and `deno lint` pass.

Reported privately by email. Follow-up worth doing separately: add a `SECURITY.md` so reports have a documented channel.